### PR TITLE
fix: post-launch polish — Node 22 cron, webhook alert, copy

### DIFF
--- a/.github/workflows/ingest-odometer.yml
+++ b/.github/workflows/ingest-odometer.yml
@@ -34,11 +34,17 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
-      # These scripts only need pg + tsx — install just those (no lockfile
-      # dependency, avoids pulling the whole CRA app into the runner).
-      - run: npm install --no-save pg tsx
+      # These scripts only need pg + tsx. Install ONLY those: temporarily hide
+      # package.json so npm doesn't pull the whole CRA dependency tree (~1600
+      # packages) into the runner — just pg + tsx land in ./node_modules, which is
+      # where the scripts in scripts/ resolve their imports from.
+      - name: Install pg + tsx only
+        run: |
+          mv package.json _package.json
+          npm install --no-save --no-package-lock --no-audit --no-fund pg tsx
+          mv _package.json package.json
 
       - name: Compute window start
         id: win

--- a/api/certificate/[...slug].ts
+++ b/api/certificate/[...slug].ts
@@ -227,8 +227,25 @@ async function handleWebhook(req: VercelRequest, res: VercelResponse) {
 		return res.status(400).json({ error: 'Invalid webhook' })
 	}
 
-	// Unknown/unhandled event or bad signature — ack so the provider stops retrying.
-	if (!parsed || !parsed.paid || !parsed.certificateCode) {
+	// Bad signature / unhandled event, or not a completed payment — ack so the
+	// provider stops retrying.
+	if (!parsed?.paid) {
+		return res.status(200).json({ received: true })
+	}
+
+	// Paid, but no VIN/certificate context — someone bought via the public Lemon
+	// Squeezy checkout directly, bypassing our flow, so there's nothing to issue.
+	// Never keep the money silently: alert for a manual refund.
+	if (!parsed.certificateCode) {
+		await logEvent('certificate_error', {
+			stage: 'webhook_no_code',
+			ref: parsed.ref
+		})
+		await sendOperatorAlert('Platba bez VIN (přímý checkout)', [
+			'Přišla platba bez kontextu certifikátu — zřejmě přímé otevření Lemon Squeezy checkoutu.',
+			`Provider ref: ${parsed.ref ?? '?'}`,
+			'Certifikát nelze vystavit. Vyřešte ručně: vraťte platbu, nebo si od zákazníka vyžádejte VIN.'
+		])
 		return res.status(200).json({ received: true })
 	}
 

--- a/src/components/ProductComparison.tsx
+++ b/src/components/ProductComparison.tsx
@@ -57,13 +57,13 @@ const ProductComparison: React.FC<ProductComparisonProps> = ({
 					<Icon name='check' size={15} /> Dovoz a stav vozidla
 				</li>
 				<li>
-					<Icon name='check' size={15} /> Přehledné, sdílitelné PDF s QR ověřením
+					<Icon name='check' size={15} /> Přehledné PDF s QR ověřením ke sdílení
 				</li>
 			</ul>
 			<p className='product-when'>
-				Přehledný, sdílitelný a ověřitelný PDF výpis s nejdůležitějšími údaji o
-				vozidle z registru a STK ČR — ideální jako podklad při prodeji i koupi
-				nebo pro vlastní evidenci.
+				Přehledný a ověřitelný PDF výpis s nejdůležitějšími údaji o vozidle z
+				registru a STK ČR — ideální podklad při prodeji i koupi nebo pro vlastní
+				evidenci.
 			</p>
 			{certificateCta}
 		</div>


### PR DESCRIPTION
## Post-launch polish (3 small commits)

- **ci(odometer):** bump the ingest workflow runner to **Node 22** and install only `pg`+`tsx` (temporarily hides `package.json` so npm doesn't pull the CRA tree into the runner).
- **fix(certificate):** the webhook now **alerts the operator on a paid order with no VIN** (someone using the public gateway checkout directly) instead of silently keeping the money.
- **copy(certificate):** ProductComparison wording — add mileage to our card (conditional on availability), sharpen the value prop, soften "odhalí"→"může odhalit stočení", reframe the partner card, drop the non-word "sdílitelné".

No app-behaviour change for normal visitors (certificate still flag-gated). tsc + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
