### PR TITLE
feat: Comgate payment provider (default), Lemon Squeezy fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,22 +24,7 @@ OPERATOR_EMAIL=
 # --- Cron ---
 CRON_SECRET=
 
-# --- Payment provider switch ---
-# Which gateway processes certificate payments: 'comgate' (Czech PSP — we are the
-# seller, no VAT as neplátce, cheaper per 99 Kč) or 'lemonsqueezy' (Merchant of
-# Record fallback). Defaults to comgate if unset.
-PAYMENT_PROVIDER=comgate
-
-# --- Comgate (Czech PSP) ---
-# merchant + secret from the Comgate client portal (e-shop settings > connection).
-# Set the notification (push) URL in that same portal to:
-#   https://vininfo.cz/api/certificate/webhook
-# Off production the code sends test=true so payments are sandbox/test charges.
-COMGATE_MERCHANT=
-COMGATE_SECRET=
-
 # --- Certificate sales (Lemon Squeezy — Merchant of Record, handles EU VAT) ---
-# Fallback provider (used when PAYMENT_PROVIDER=lemonsqueezy).
 # Store id is shared between test and live. The variant id, API key and webhook
 # secret DIFFER by mode: outside production the code prefers the *_TEST values
 # (falling back to the base name); production uses the base (live) names.

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,22 @@ OPERATOR_EMAIL=
 # --- Cron ---
 CRON_SECRET=
 
+# --- Payment provider switch ---
+# Which gateway processes certificate payments: 'comgate' (Czech PSP — we are the
+# seller, no VAT as neplátce, cheaper per 99 Kč) or 'lemonsqueezy' (Merchant of
+# Record fallback). Defaults to comgate if unset.
+PAYMENT_PROVIDER=comgate
+
+# --- Comgate (Czech PSP) ---
+# merchant + secret from the Comgate client portal (e-shop settings > connection).
+# Set the notification (push) URL in that same portal to:
+#   https://vininfo.cz/api/certificate/webhook
+# Off production the code sends test=true so payments are sandbox/test charges.
+COMGATE_MERCHANT=
+COMGATE_SECRET=
+
 # --- Certificate sales (Lemon Squeezy — Merchant of Record, handles EU VAT) ---
+# Fallback provider (used when PAYMENT_PROVIDER=lemonsqueezy).
 # Store id is shared between test and live. The variant id, API key and webhook
 # secret DIFFER by mode: outside production the code prefers the *_TEST values
 # (falling back to the base name); production uses the base (live) names.

--- a/api/_certificate.ts
+++ b/api/_certificate.ts
@@ -24,8 +24,9 @@ export function generateDownloadToken(): string {
 }
 
 /**
- * Certificate display price in whole crowns (VAT-inclusive). Display-only — the
- * real charge is the Creem product's configured price, so keep them in sync.
+ * Certificate price in whole crowns. With Comgate this is the amount actually
+ * charged (passed to /create). We are a neplátce, so the price is final with no
+ * VAT. (With the Lemon Squeezy fallback the real charge is the variant price.)
  */
 export function getCertificatePriceCzk(): number {
 	const raw = Number(process.env.CERTIFICATE_PRICE_CZK)

--- a/api/_email.ts
+++ b/api/_email.ts
@@ -227,12 +227,24 @@ interface CertificateEmailParams {
 	downloadUrl: string
 	/** Public verification page. */
 	verifyUrl: string
+	/** Amount paid in whole crowns — for the receipt (doklad o zaplacení). */
+	amountCzk: number
+	/** Payment date — for the receipt. */
+	paidAt: Date
+}
+
+/** Seller identity for the doklad o zaplacení (neplátce — no VAT). */
+const SELLER_NAME = 'Bc. Václav Gabriel'
+const SELLER_ICO = '88350207'
+
+function fmtReceiptDate(d: Date): string {
+	return `${d.getDate()}. ${d.getMonth() + 1}. ${d.getFullYear()}`
 }
 
 export function generateCertificateEmailHtml(
 	params: CertificateEmailParams
 ): string {
-	const { code, vin, downloadUrl, verifyUrl } = params
+	const { code, vin, downloadUrl, verifyUrl, amountCzk, paidAt } = params
 	const preheader = `Váš certifikát historie vozidla (${code}) je připravený ke stažení.`
 	return `<!DOCTYPE html>
 <html lang="cs">
@@ -280,7 +292,22 @@ export function generateCertificateEmailHtml(
 								</tr>
 							</table>
 							<p class="email-text-muted" style="color: #888; font-size: 14px; margin: 16px 0 0;">Pravost certifikátu si kdokoliv ověří na <a href="${verifyUrl}" style="color: #2e7d32;">${verifyUrl}</a>. Odkaz na stažení je osobní — nesdílejte ho.</p>
-							<p class="email-text-muted" style="color: #888; font-size: 13px; margin: 16px 0 0;">Výpis vychází z veřejných dat registru a neobsahuje stav tachometru, záznamy o nehodách ani zástavy.</p>
+							<p class="email-text-muted" style="color: #888; font-size: 13px; margin: 16px 0 0;">Výpis vychází z veřejných dat registru a STK a neobsahuje záznamy o nehodách ani zástavy.</p>
+							<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 24px 0 0;">
+								<tr>
+									<td style="border-top: 1px solid #e9ecef; padding-top: 16px;">
+										<p class="email-text" style="color: #333; font-weight: 600; margin: 0 0 8px; font-size: 14px;">Doklad o zaplacení</p>
+										<p class="email-text-muted" style="color: #777; font-size: 13px; margin: 0; line-height: 1.9;">
+											Položka: Certifikát historie vozidla<br>
+											Variabilní symbol / číslo certifikátu: ${code}<br>
+											Částka: ${amountCzk} Kč<br>
+											Datum úhrady: ${fmtReceiptDate(paidAt)}<br>
+											Prodávající: ${SELLER_NAME}, IČO ${SELLER_ICO}<br>
+											Nejsme plátci DPH.
+										</p>
+									</td>
+								</tr>
+							</table>
 						</td>
 					</tr>
 					<tr>
@@ -309,7 +336,15 @@ export function generateCertificateEmailText(
 		`Stáhnout certifikát (PDF): ${params.downloadUrl}`,
 		`Ověřit pravost: ${params.verifyUrl}`,
 		'',
-		'Odkaz na stažení je osobní — nesdílejte ho. Výpis vychází z veřejných dat registru a neobsahuje stav tachometru, záznamy o nehodách ani zástavy.',
+		'Odkaz na stažení je osobní — nesdílejte ho. Výpis vychází z veřejných dat registru a STK a neobsahuje záznamy o nehodách ani zástavy.',
+		'',
+		'Doklad o zaplacení',
+		'Položka: Certifikát historie vozidla',
+		`Variabilní symbol / číslo certifikátu: ${params.code}`,
+		`Částka: ${params.amountCzk} Kč`,
+		`Datum úhrady: ${fmtReceiptDate(params.paidAt)}`,
+		`Prodávající: ${SELLER_NAME}, IČO ${SELLER_ICO}`,
+		'Nejsme plátci DPH.',
 		'',
 		'— VINInfo.cz (https://vininfo.cz)'
 	].join('\n')

--- a/api/_email.ts
+++ b/api/_email.ts
@@ -233,8 +233,9 @@ interface CertificateEmailParams {
 	paidAt: Date
 }
 
-/** Seller identity for the doklad o zaplacení (neplátce — no VAT). */
+/** Seller identity for the doklad o zaplacení (§435 obč. zák.; neplátce — no VAT). */
 const SELLER_NAME = 'Bc. Václav Gabriel'
+const SELLER_ADDRESS = 'Krkoškova 1662/37, 613 00 Brno'
 const SELLER_ICO = '88350207'
 
 function fmtReceiptDate(d: Date): string {
@@ -302,8 +303,8 @@ export function generateCertificateEmailHtml(
 											Variabilní symbol / číslo certifikátu: ${code}<br>
 											Částka: ${amountCzk} Kč<br>
 											Datum úhrady: ${fmtReceiptDate(paidAt)}<br>
-											Prodávající: ${SELLER_NAME}, IČO ${SELLER_ICO}<br>
-											Nejsme plátci DPH.
+											Prodávající: ${SELLER_NAME}, ${SELLER_ADDRESS}, IČO ${SELLER_ICO}<br>
+											Fyzická osoba zapsaná v živnostenském rejstříku. Nejsme plátci DPH.
 										</p>
 									</td>
 								</tr>
@@ -343,8 +344,8 @@ export function generateCertificateEmailText(
 		`Variabilní symbol / číslo certifikátu: ${params.code}`,
 		`Částka: ${params.amountCzk} Kč`,
 		`Datum úhrady: ${fmtReceiptDate(params.paidAt)}`,
-		`Prodávající: ${SELLER_NAME}, IČO ${SELLER_ICO}`,
-		'Nejsme plátci DPH.',
+		`Prodávající: ${SELLER_NAME}, ${SELLER_ADDRESS}, IČO ${SELLER_ICO}`,
+		'Fyzická osoba zapsaná v živnostenském rejstříku. Nejsme plátci DPH.',
 		'',
 		'— VINInfo.cz (https://vininfo.cz)'
 	].join('\n')

--- a/api/_payments.ts
+++ b/api/_payments.ts
@@ -1,25 +1,26 @@
 /**
  * Thin payment-provider abstraction for one-off certificate purchases.
  *
- * Provider: Lemon Squeezy (Merchant of Record). As MoR, Lemon Squeezy is the
- * legal seller and collects + remits EU VAT for us, so we never file a VAT
- * return. Chosen because it is the only fast/self-serve MoR that bills in CZK
- * (Creem is USD/EUR only); Paddle also does CZK but is approval-gated. Only this
- * file knows about the provider — swapping it means reimplementing
- * `createCheckout` + `verifyAndParseWebhook` and nothing else.
+ * Two providers are implemented; pick via the PAYMENT_PROVIDER env var:
+ *   - 'comgate'      — Comgate (Czech PSP). We (the OSVČ) are the seller; as a
+ *                      neplátce we charge no VAT on CZ sales. Its fees are a
+ *                      domestic supply, so they don't trigger "identifikovaná
+ *                      osoba" (unlike a foreign MoR). Cheaper per 99 Kč sale.
+ *   - 'lemonsqueezy' — Lemon Squeezy (Merchant of Record). Kept as a fallback:
+ *                      LS is the legal seller and remits EU VAT for us, but its
+ *                      fees are a foreign service. Left in place so we can switch
+ *                      back by flipping PAYMENT_PROVIDER.
  *
- * Implemented with plain fetch + crypto (no SDK). The charged amount lives on the
- * Lemon Squeezy variant (LEMONSQUEEZY_VARIANT_ID), so our CERTIFICATE_PRICE_CZK
- * is display-only and must match the variant price.
+ * Only this file knows about the providers. The rest of the app uses
+ * `createCheckout` + `verifyAndParseWebhook`, which dispatch on PAYMENT_PROVIDER.
+ * Implemented with plain fetch + crypto (no SDK).
  */
 import crypto from 'crypto'
 
-/** Stored on each certificate row so we can attribute webhooks to a provider. */
-export const PAYMENT_PROVIDER = 'lemonsqueezy'
-
-const API_BASE = 'https://api.lemonsqueezy.com/v1'
-// Lemon Squeezy speaks JSON:API — both headers are required.
-const JSONAPI = 'application/vnd.api+json'
+/** Active provider. Defaults to Comgate; set PAYMENT_PROVIDER=lemonsqueezy to use
+ *  the MoR fallback. Stored on each certificate row for webhook attribution. */
+export const PAYMENT_PROVIDER: 'comgate' | 'lemonsqueezy' =
+	process.env.PAYMENT_PROVIDER === 'lemonsqueezy' ? 'lemonsqueezy' : 'comgate'
 
 function env(name: string): string {
 	const v = process.env[name]
@@ -37,12 +38,174 @@ function isLiveMode(): boolean {
 	return process.env.NODE_ENV === 'production'
 }
 
+/** Timing-safe string compare (equal-length-guarded). */
+function safeEqual(a: string, b: string): boolean {
+	const ab = Buffer.from(a)
+	const bb = Buffer.from(b)
+	return ab.length === bb.length && crypto.timingSafeEqual(ab, bb)
+}
+
+export interface CheckoutParams {
+	/** Display price in whole crowns. With Comgate this is the charged amount;
+	 *  with Lemon Squeezy the real charge is the variant price (display-only). */
+	amountCzk: number
+	email: string
+	/** Public certificate code — round-trips so the webhook can match our row. */
+	certificateCode: string
+	vin: string
+	successUrl: string
+	cancelUrl: string
+}
+
+export interface CheckoutResult {
+	/** Hosted payment page to redirect the buyer to. */
+	url: string
+	/** Provider reference (checkout/transaction id, if any) — stored as provider_ref. */
+	ref: string | null
+}
+
+export interface WebhookResult {
+	/** Provider reference to match against `provider_ref` (may be null). */
+	ref: string | null
+	/** The certificate code carried back by the provider — the primary match key. */
+	certificateCode: string | null
+	/** True once the payment is actually captured. */
+	paid: boolean
+}
+
+// --- Public interface: dispatch on the active provider ---------------------
+
+export async function createCheckout(
+	params: CheckoutParams
+): Promise<CheckoutResult> {
+	return PAYMENT_PROVIDER === 'comgate'
+		? comgateCreateCheckout(params)
+		: lemonSqueezyCreateCheckout(params)
+}
+
 /**
- * Resolve a mode-specific Lemon Squeezy value. The API key, webhook secret and
- * product variant id all differ between test and live mode (the store id is
- * shared). In non-live mode (local, preview, tests) prefer the `_TEST` variant,
- * falling back to the base name; in live mode always use the base (live) name.
+ * Verify + parse a payment webhook. Returns null for unknown/unhandled events or
+ * a failed verification — the caller treats null as "ignore, respond 2xx" so the
+ * provider stops retrying. Async because Comgate re-queries the authoritative
+ * status server-to-server.
  */
+export async function verifyAndParseWebhook(
+	rawBody: Buffer | string,
+	signature: string | undefined
+): Promise<WebhookResult | null> {
+	return PAYMENT_PROVIDER === 'comgate'
+		? comgateVerifyWebhook(rawBody)
+		: lemonSqueezyVerifyWebhook(rawBody, signature)
+}
+
+// --- Comgate (Czech PSP, HTTP API v1.0, form-encoded) ----------------------
+//
+// Auth = merchant + secret in the body. The push notification carries our secret
+// (so we can authenticate it) plus refId (= our certificate code) and status; we
+// additionally re-query /status, which Comgate recommends as the source of truth.
+
+const COMGATE_BASE = 'https://payments.comgate.cz/v1.0'
+
+function comgateForm(params: Record<string, string>): string {
+	return new URLSearchParams(params).toString()
+}
+
+async function comgatePost(
+	path: string,
+	params: Record<string, string>
+): Promise<URLSearchParams> {
+	const res = await fetch(`${COMGATE_BASE}${path}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: comgateForm(params)
+	})
+	const text = await res.text()
+	if (!res.ok) {
+		throw new Error(`Comgate ${path} HTTP ${res.status}: ${text}`)
+	}
+	return new URLSearchParams(text)
+}
+
+async function comgateCreateCheckout(
+	params: CheckoutParams
+): Promise<CheckoutResult> {
+	const out = await comgatePost('/create', {
+		merchant: env('COMGATE_MERCHANT'),
+		secret: env('COMGATE_SECRET'),
+		price: String(Math.round(params.amountCzk * 100)), // haléře
+		curr: 'CZK',
+		label: 'Certifikát historie vozidla',
+		refId: params.certificateCode,
+		email: params.email,
+		method: 'ALL',
+		prepareOnly: 'true',
+		lang: 'cs',
+		country: 'CZ',
+		url_paid: params.successUrl,
+		url_cancelled: params.cancelUrl,
+		url_pending: params.successUrl,
+		// Notification URL is set in the Comgate portal (e-shop connection); it must
+		// point at /api/certificate/webhook.
+		...(isLiveMode() ? {} : { test: 'true' })
+	})
+
+	if (out.get('code') !== '0') {
+		throw new Error(`Comgate create failed: ${out.toString()}`)
+	}
+	const url = out.get('redirect')
+	if (!url) {
+		throw new Error('Comgate did not return a redirect URL')
+	}
+	return { url, ref: out.get('transId') }
+}
+
+/** Confirm a transaction is actually PAID via the authoritative status method. */
+async function comgateConfirmPaid(transId: string): Promise<boolean> {
+	const out = await comgatePost('/status', {
+		merchant: env('COMGATE_MERCHANT'),
+		secret: env('COMGATE_SECRET'),
+		transId
+	})
+	return out.get('code') === '0' && out.get('status') === 'PAID'
+}
+
+async function comgateVerifyWebhook(
+	rawBody: Buffer | string
+): Promise<WebhookResult | null> {
+	const body = new URLSearchParams(
+		typeof rawBody === 'string' ? rawBody : rawBody.toString('utf8')
+	)
+	const transId = body.get('transId')
+	if (!transId) {
+		return null
+	}
+	// Authenticity: the notification echoes our secret. Verify before trusting it.
+	const notifSecret = body.get('secret')
+	if (!notifSecret || !safeEqual(notifSecret, env('COMGATE_SECRET'))) {
+		return null
+	}
+	// Source of truth: re-query the status server-to-server (Comgate's advice).
+	const paid = await comgateConfirmPaid(transId)
+	return { ref: transId, certificateCode: body.get('refId'), paid }
+}
+
+/** Body Comgate expects in the 2xx notification acknowledgement. */
+export function webhookAckBody(): { contentType: string; body: string } {
+	return PAYMENT_PROVIDER === 'comgate'
+		? { contentType: 'text/plain', body: 'code=0&message=OK' }
+		: { contentType: 'application/json', body: JSON.stringify({ received: true }) }
+}
+
+// --- Lemon Squeezy (Merchant of Record, JSON:API) — kept as a fallback ------
+//
+// The charged amount lives on the LS variant (LEMONSQUEEZY_VARIANT_ID), so
+// CERTIFICATE_PRICE_CZK is display-only and must match the variant price. API
+// key / webhook secret / variant id differ by test vs live mode (store id shared).
+
+const LS_API_BASE = 'https://api.lemonsqueezy.com/v1'
+const LS_JSONAPI = 'application/vnd.api+json'
+
+/** Resolve a mode-specific Lemon Squeezy value (prefers *_TEST off production). */
 function lsModeEnv(base: string): string {
 	if (!isLiveMode()) {
 		const test = process.env[`${base}_TEST`]
@@ -51,27 +214,7 @@ function lsModeEnv(base: string): string {
 	return env(base)
 }
 
-export interface CheckoutParams {
-	/** Display price in whole crowns — informational; the real charge is the
-	 *  Lemon Squeezy variant's configured price. Kept for the stored record. */
-	amountCzk: number
-	email: string
-	/** Public certificate code — round-trips via checkout custom data. */
-	certificateCode: string
-	vin: string
-	successUrl: string
-	/** Unused by Lemon Squeezy — kept for interface stability. */
-	cancelUrl: string
-}
-
-export interface CheckoutResult {
-	/** Hosted payment page to redirect the buyer to. */
-	url: string
-	/** Provider reference (checkout id, if returned) — stored as provider_ref. */
-	ref: string | null
-}
-
-export async function createCheckout(
+async function lemonSqueezyCreateCheckout(
 	params: CheckoutParams
 ): Promise<CheckoutResult> {
 	const body = {
@@ -80,18 +223,13 @@ export async function createCheckout(
 			attributes: {
 				checkout_data: {
 					email: params.email,
-					// Default the checkout to Czechia (our audience) so VAT/locale resolve
-					// correctly; the buyer can still change it.
 					billing_address: { country: 'CZ' },
-					// Round-trips to the webhook (meta.custom_data) to match our row.
 					custom: { certificate_code: params.certificateCode, vin: params.vin }
 				},
 				product_options: { redirect_url: params.successUrl }
 			},
 			relationships: {
-				store: {
-					data: { type: 'stores', id: env('LEMONSQUEEZY_STORE_ID') }
-				},
+				store: { data: { type: 'stores', id: env('LEMONSQUEEZY_STORE_ID') } },
 				variant: {
 					data: { type: 'variants', id: lsModeEnv('LEMONSQUEEZY_VARIANT_ID') }
 				}
@@ -99,11 +237,11 @@ export async function createCheckout(
 		}
 	}
 
-	const res = await fetch(`${API_BASE}/checkouts`, {
+	const res = await fetch(`${LS_API_BASE}/checkouts`, {
 		method: 'POST',
 		headers: {
-			Accept: JSONAPI,
-			'Content-Type': JSONAPI,
+			Accept: LS_JSONAPI,
+			'Content-Type': LS_JSONAPI,
 			Authorization: `Bearer ${lsModeEnv('LEMONSQUEEZY_API_KEY')}`
 		},
 		body: JSON.stringify(body)
@@ -124,24 +262,12 @@ export async function createCheckout(
 	return { url, ref: json.data?.id ?? null }
 }
 
-export interface WebhookResult {
-	/** Provider reference to match against `provider_ref` (may be null). */
-	ref: string | null
-	/** The certificate code carried in custom data — the primary match key. */
-	certificateCode: string | null
-	/** True once the payment is actually captured. */
-	paid: boolean
-}
-
 /**
- * Verify the webhook signature and extract what the endpoint needs. Returns null
- * for unknown/unhandled events or a bad signature — the caller treats null as
- * "ignore, respond 200" so the provider stops retrying.
- *
- * Signature is HMAC-SHA256(secret, rawBody) compared in hex (X-Signature header),
- * so the webhook route disables body parsing and passes the exact bytes received.
+ * Verify the LS webhook signature (HMAC-SHA256(secret, rawBody) hex, X-Signature
+ * header) and extract what the endpoint needs. The route disables body parsing
+ * and passes the exact bytes so the HMAC matches.
  */
-export function verifyAndParseWebhook(
+function lemonSqueezyVerifyWebhook(
 	rawBody: Buffer | string,
 	signature: string | undefined
 ): WebhookResult | null {
@@ -152,11 +278,7 @@ export function verifyAndParseWebhook(
 		.createHmac('sha256', secret)
 		.update(rawBody)
 		.digest('hex')
-
-	const sigBuf = Buffer.from(signature)
-	const expBuf = Buffer.from(expected)
-	if (sigBuf.length !== expBuf.length) return null
-	if (!crypto.timingSafeEqual(sigBuf, expBuf)) return null
+	if (!safeEqual(signature, expected)) return null
 
 	let event: {
 		meta?: { event_name?: string; custom_data?: { certificate_code?: string } }
@@ -170,7 +292,6 @@ export function verifyAndParseWebhook(
 		return null
 	}
 
-	// One-off product purchase → `order_created`.
 	if (event.meta?.event_name !== 'order_created') {
 		return null
 	}
@@ -178,7 +299,6 @@ export function verifyAndParseWebhook(
 	return {
 		ref: event.data?.id ?? null,
 		certificateCode: event.meta?.custom_data?.certificate_code ?? null,
-		// `order_created` only fires on a real order; status check is belt-and-braces.
 		paid: status ? status === 'paid' : true
 	}
 }

--- a/api/certificate/[...slug].ts
+++ b/api/certificate/[...slug].ts
@@ -19,7 +19,8 @@ import { rateLimit } from '../_rateLimit'
 import {
 	createCheckout,
 	PAYMENT_PROVIDER,
-	verifyAndParseWebhook
+	verifyAndParseWebhook,
+	webhookAckBody
 } from '../_payments'
 import { renderCertificatePdf } from '../_certificatePdf'
 import {
@@ -215,13 +216,20 @@ async function handleCreate(req: VercelRequest, res: VercelResponse) {
 	return res.status(201).json({ code, checkoutUrl: checkout.url })
 }
 
+/** Provider-appropriate 2xx acknowledgement (Comgate wants `code=0&message=OK`). */
+function ackWebhook(res: VercelResponse) {
+	const { contentType, body } = webhookAckBody()
+	res.setHeader('Content-Type', contentType)
+	return res.status(200).send(body)
+}
+
 /** POST /api/certificate/webhook — mark paid + deliver. Idempotent. */
 async function handleWebhook(req: VercelRequest, res: VercelResponse) {
-	let parsed: ReturnType<typeof verifyAndParseWebhook>
+	let parsed: Awaited<ReturnType<typeof verifyAndParseWebhook>>
 	try {
 		const rawBody = await readRawBody(req)
 		const signature = req.headers['x-signature'] as string | undefined
-		parsed = verifyAndParseWebhook(rawBody, signature)
+		parsed = await verifyAndParseWebhook(rawBody, signature)
 	} catch (error) {
 		console.error('Webhook verification error:', error)
 		return res.status(400).json({ error: 'Invalid webhook' })
@@ -230,7 +238,7 @@ async function handleWebhook(req: VercelRequest, res: VercelResponse) {
 	// Bad signature / unhandled event, or not a completed payment — ack so the
 	// provider stops retrying.
 	if (!parsed?.paid) {
-		return res.status(200).json({ received: true })
+		return ackWebhook(res)
 	}
 
 	// Paid, but no VIN/certificate context — someone bought via the public Lemon
@@ -242,11 +250,11 @@ async function handleWebhook(req: VercelRequest, res: VercelResponse) {
 			ref: parsed.ref
 		})
 		await sendOperatorAlert('Platba bez VIN (přímý checkout)', [
-			'Přišla platba bez kontextu certifikátu — zřejmě přímé otevření Lemon Squeezy checkoutu.',
+			'Přišla platba bez kontextu certifikátu — zřejmě přímé otevření platební brány.',
 			`Provider ref: ${parsed.ref ?? '?'}`,
 			'Certifikát nelze vystavit. Vyřešte ručně: vraťte platbu, nebo si od zákazníka vyžádejte VIN.'
 		])
-		return res.status(200).json({ received: true })
+		return ackWebhook(res)
 	}
 
 	await ensureTables()
@@ -274,13 +282,13 @@ async function handleWebhook(req: VercelRequest, res: VercelResponse) {
 				code: parsed.certificateCode
 			})
 			await sendOperatorAlert('Platba bez certifikátu', [
-				'Lemon Squeezy potvrdil platbu, ale neznáme odpovídající certifikát.',
+				'Platební brána potvrdila platbu, ale neznáme odpovídající certifikát.',
 				`Kód: ${parsed.certificateCode}`,
 				`Provider ref: ${parsed.ref ?? '?'}`,
 				'Zákazník zaplatil, ale certifikát nelze doručit — zkontrolujte ručně.'
 			])
 		}
-		return res.status(200).json({ received: true })
+		return ackWebhook(res)
 	}
 
 	const cert = rows[0] as {

--- a/api/certificate/[...slug].ts
+++ b/api/certificate/[...slug].ts
@@ -315,7 +315,9 @@ async function handleWebhook(req: VercelRequest, res: VercelResponse) {
 			code: cert.code,
 			vin: cert.vin,
 			downloadUrl: `${base}/api/certificate/${cert.code}?token=${cert.download_token}`,
-			verifyUrl: `${base}/overit/${cert.code}`
+			verifyUrl: `${base}/overit/${cert.code}`,
+			amountCzk: cert.amount_czk ?? getCertificatePriceCzk(),
+			paidAt: new Date()
 		})
 	} catch (error) {
 		// The certificate is paid + issued; a failed email must not 500 the webhook

--- a/src/components/CertificateCheckoutModal.tsx
+++ b/src/components/CertificateCheckoutModal.tsx
@@ -78,8 +78,9 @@ const CertificateCheckoutModal: React.FC<CertificateCheckoutModalProps> = ({
 						<div className='modal-body'>
 							<p className='mb-2'>
 								Přehled historie vozidla pro VIN <strong>{vin}</strong>{' '}
-								zpracovaný z dat registru silničních vozidel ČR — vlastníci, STK,
-								dovoz a stav vozidla v ověřitelném PDF.
+								zpracovaný z dat registru silničních vozidel ČR a STK — vlastníci,
+								historie STK, stav tachometru, dovoz a stav vozidla v ověřitelném
+								PDF.
 							</p>
 							<p className='mb-3'>
 								<a
@@ -133,8 +134,8 @@ const CertificateCheckoutModal: React.FC<CertificateCheckoutModalProps> = ({
 								</div>
 							)}
 							<p className='text-muted-ink small mt-3 mb-0'>
-								Cena zahrnuje DPH. Výpis vychází z veřejných dat registru a
-								neobsahuje stav tachometru, záznamy o nehodách ani zástavy.
+								Cena je konečná (nejsme plátci DPH). Výpis vychází z veřejných dat
+								registru a STK a neobsahuje záznamy o nehodách ani zástavy.
 							</p>
 						</div>
 						<div className='modal-footer'>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,6 +34,14 @@ const Footer: React.FC = () => {
 							<br />
 							Kontakt: vininfo(zavináč)mail.vininfo.cz
 						</p>
+						<p
+							className='text-muted-ink mb-0 mt-2'
+							style={{ fontSize: '0.75rem' }}
+						>
+							Provozovatel: Bc. Václav Gabriel, Krkoškova 1662/37, 613 00 Brno,
+							IČO 88350207. Fyzická osoba zapsaná v živnostenském rejstříku.
+							Neplátce DPH.
+						</p>
 
 						<h6 className='fw-bold mb-3 mt-4'>
 							<span className='heading-accent'>Právní info</span>

--- a/src/components/VehicleInfo.tsx
+++ b/src/components/VehicleInfo.tsx
@@ -19,8 +19,8 @@ import Icon, { type IconName } from './Icon'
 import ProductComparison from './ProductComparison'
 import VehicleHistoryPanel from './VehicleHistoryPanel'
 
-// Display price of our own certificate (VAT incl.). Must match the backend
-// CERTIFICATE_PRICE_CZK env (api/_certificate.ts) and the Creem product price.
+// Display price of our own certificate (final price; we are a neplátce, no VAT).
+// Must match the backend CERTIFICATE_PRICE_CZK env (api/_certificate.ts).
 const CERTIFICATE_PRICE_CZK = 99
 
 const CATEGORY_ICONS: Record<VehicleFieldCategoryId, IconName> = {

--- a/src/pages/CertificateLandingPage.tsx
+++ b/src/pages/CertificateLandingPage.tsx
@@ -10,7 +10,7 @@ import { isCertificateEnabled } from '../config/featureFlags'
 const PRICE_CZK = 99
 
 const PAGE_TITLE = `Certifikát historie vozidla z registru ČR za ${PRICE_CZK} Kč | VIN Info.cz`
-const PAGE_DESCRIPTION = `Přehledný certifikát historie vozidla zpracovaný z dat registru silničních vozidel ČR — vlastníci, STK, dovoz a stav vozidla. Ihned, v ověřitelném PDF, za ${PRICE_CZK} Kč.`
+const PAGE_DESCRIPTION = `Přehledný certifikát historie vozidla zpracovaný z dat registru silničních vozidel ČR a STK — vlastníci, STK, stav tachometru, dovoz a stav vozidla. Ihned, v ověřitelném PDF, za ${PRICE_CZK} Kč.`
 const CANONICAL_URL = 'https://vininfo.cz/overeny-vypis-vozidla'
 
 const CertificateLandingPage: React.FC = () => {
@@ -109,10 +109,10 @@ const CertificateLandingPage: React.FC = () => {
 							Přehled historie vozidla z registru ČR za {PRICE_CZK} Kč
 						</h1>
 						<p className='lead mb-4'>
-							Data z registru silničních vozidel ČR jsou špatně čitelná — my je
-							za vás zpracujeme do srozumitelného přehledu: vlastníci, STK, dovoz
-							a stav vozidla. Ihned, v ověřitelném PDF — podklad pro koupi i
-							prodej vozidla.
+							Data z registru silničních vozidel ČR a STK jsou špatně čitelná — my
+							je za vás zpracujeme do srozumitelného přehledu: vlastníci, STK, stav
+							tachometru, dovoz a stav vozidla. Ihned, v ověřitelném PDF — podklad
+							pro koupi i prodej vozidla.
 						</p>
 						<form onSubmit={handleSubmit}>
 							<label htmlFor='landing-vin' className='form-label fw-semibold'>
@@ -187,7 +187,8 @@ const CertificateLandingPage: React.FC = () => {
 						<ol className='mb-0' style={{ lineHeight: 2 }}>
 							<li>Zadáte VIN a zobrazíte si vozidlo (náhled je zdarma).</li>
 							<li>
-								Na detailu vozidla koupíte certifikát za {PRICE_CZK} Kč (vč. DPH).
+								Na detailu vozidla koupíte certifikát za {PRICE_CZK} Kč (konečná
+								cena).
 							</li>
 							<li>
 								Certifikát v PDF dostanete e-mailem a ke stažení — s QR kódem pro

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -2,39 +2,46 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import Footer from '../components/Footer'
 import Navigation from '../components/Navigation'
+import { isCertificateEnabled } from '../config/featureFlags'
 
 const TermsPage: React.FC = () => {
+	// The paid certificate (§6) is hidden until the product launches; the later
+	// sections renumber so there's no gap when it's off.
+	const certOn = isCertificateEnabled()
 	return (
 		<>
 			<Navigation />
 			<main className='container mt-5'>
 				<h1>Obchodní podmínky</h1>
-				<p className='text-muted'>
-					Platné od 1. 1. 2026
-				</p>
+				<p className='text-muted'>Platné od 1. 1. 2026</p>
 
 				<section className='mt-4'>
 					<h2 className='h4'>1. Úvodní ustanovení</h2>
 					<p>
-						Tyto obchodní podmínky (dále jen „podmínky") upravují práva a povinnosti
-						uživatelů služby VINInfo (dále jen „služba") provozované fyzickou osobou
-						Bc. Václav Gabriel, IČO 88350207 (dále jen „provozovatel").
+						Tyto obchodní podmínky (dále jen „podmínky") upravují práva a
+						povinnosti uživatelů služby VINInfo (dále jen „služba") provozované
+						fyzickou osobou Bc. Václav Gabriel, IČO 88350207 (dále jen
+						„provozovatel").
 					</p>
 					<p>
-						Používáním služby uživatel souhlasí s těmito podmínkami a zavazuje se
-						je dodržovat.
+						Používáním služby uživatel souhlasí s těmito podmínkami a zavazuje
+						se je dodržovat.
 					</p>
 				</section>
 
 				<section className='mt-4'>
 					<h2 className='h4'>2. Popis služby</h2>
-					<p>
-						Služba VINInfo umožňuje uživatelům:
-					</p>
+					<p>Služba VINInfo umožňuje uživatelům:</p>
 					<ul>
-						<li>Vyhledávat informace o vozidlech podle VIN, čísla technického průkazu nebo registrační značky</li>
+						<li>
+							Vyhledávat informace o vozidlech podle VIN, čísla technického
+							průkazu nebo registrační značky
+						</li>
 						<li>Ukládat vozidla do osobní sekce „Moje VINInfo"</li>
-						<li>Nastavovat upozornění na důležité termíny související s provozem vozidel (STK, pojištění, servis apod.)</li>
+						<li>
+							Nastavovat upozornění na důležité termíny související s provozem
+							vozidel (STK, pojištění, servis apod.)
+						</li>
 						<li>Přijímat emailová upozornění na blížící se termíny</li>
 					</ul>
 				</section>
@@ -47,8 +54,8 @@ const TermsPage: React.FC = () => {
 						zneužitím.
 					</p>
 					<p>
-						Provozovatel si vyhrazuje právo zrušit účet uživatele, který porušuje
-						tyto podmínky nebo zneužívá službu.
+						Provozovatel si vyhrazuje právo zrušit účet uživatele, který
+						porušuje tyto podmínky nebo zneužívá službu.
 					</p>
 				</section>
 
@@ -59,100 +66,109 @@ const TermsPage: React.FC = () => {
 						GDPR (General Data Protection Regulation) a zákonem č. 110/2019 Sb.,
 						o zpracování osobních údajů.
 					</p>
-					<p>
-						Zpracovávané údaje zahrnují:
-					</p>
+					<p>Zpracovávané údaje zahrnují:</p>
 					<ul>
-						<li>Emailová adresa (pro účely registrace a zasílání upozornění)</li>
+						<li>
+							Emailová adresa (pro účely registrace a zasílání upozornění)
+						</li>
 						<li>Údaje o uložených vozidlech (VIN, registrační značka)</li>
 						<li>Nastavení upozornění a preferencí</li>
 					</ul>
 					<p>
 						Podrobné informace o zpracování osobních údajů naleznete v{' '}
-						<Link to='/ochrana-osobnich-udaju'>Zásadách ochrany osobních údajů</Link>.
+						<Link to='/ochrana-osobnich-udaju'>
+							Zásadách ochrany osobních údajů
+						</Link>
+						.
 					</p>
 				</section>
 
 				<section className='mt-4'>
 					<h2 className='h4'>5. Emailová komunikace</h2>
 					<p>
-						Uživatel může v nastavení účtu spravovat své preference pro příjem emailů:
+						Uživatel může v nastavení účtu spravovat své preference pro příjem
+						emailů:
 					</p>
 					<ul>
 						<li>
-							<strong>Notifikační emaily</strong> – upozornění na blížící se termíny
-							STK, pojištění, servisu apod. Tyto emaily jsou součástí služby a lze
-							je kdykoliv vypnout v nastavení účtu.
+							<strong>Notifikační emaily</strong> – upozornění na blížící se
+							termíny STK, pojištění, servisu apod. Tyto emaily jsou součástí
+							služby a lze je kdykoliv vypnout v nastavení účtu.
 						</li>
 						<li>
-							<strong>Marketingové emaily</strong> – informace o novinkách, akcích
-							a partnerských nabídkách. Zasílání lze kdykoliv odmítnout při
-							registraci nebo v nastavení účtu.
+							<strong>Marketingové emaily</strong> – informace o novinkách,
+							akcích a partnerských nabídkách. Zasílání lze kdykoliv odmítnout
+							při registraci nebo v nastavení účtu.
 						</li>
 					</ul>
-					<p>
-						Každý email obsahuje odkaz pro odhlášení z odběru.
-					</p>
+					<p>Každý email obsahuje odkaz pro odhlášení z odběru.</p>
 				</section>
 
-				<section className='mt-4'>
-					<h2 className='h4'>6. Certifikát historie vozidla (placená služba)</h2>
-					<p>
-						Provozovatel nabízí jednorázový digitální produkt „Certifikát historie
-						vozidla" – přehledný výpis údajů o vozidle zpracovaný z veřejných
-						otevřených dat registru silničních vozidel ČR a evidence technických a
-						emisních prohlídek (vlastníci a provozovatelé, historie STK, historie
-						stavu tachometru z prohlídek, dovoz a stav vozidla) dodaný ve formátu
-						PDF s QR kódem pro ověření pravosti.
-					</p>
-					<ul>
-						<li>
-							<strong>Cena a DPH.</strong> Cena je uvedena u produktu před
-							dokončením objednávky a je včetně DPH.
-						</li>
-						<li>
-							<strong>Platba a fakturace.</strong> Prodej, platbu a vystavení
-							daňového dokladu zajišťuje jako prodejce (Merchant of Record)
-							společnost Lemon Squeezy (Atlas Inc.). Dokončením objednávky vstupuje
-							uživatel do smluvního vztahu rovněž s tímto poskytovatelem a souhlasí
-							s jeho podmínkami zobrazenými v platební bráně.
-						</li>
-						<li>
-							<strong>Dodání.</strong> Certifikát je dodáván elektronicky – ihned po
-							připsání platby je zaslán na uvedený e-mail a zpřístupněn ke stažení.
-						</li>
-						<li>
-							<strong>Odstoupení od smlouvy.</strong> Jde o digitální obsah dodaný
-							před uplynutím lhůty pro odstoupení. Kupující při objednávce výslovně
-							žádá o zahájení dodávání před uplynutím čtrnáctidenní lhůty pro
-							odstoupení a bere na vědomí, že tím v souladu s § 1837 písm. l) zákona
-							č. 89/2012 Sb., občanského zákoníku, ztrácí právo na odstoupení od
-							smlouvy.
-						</li>
-						<li>
-							<strong>Povaha údajů.</strong> Certifikát vychází z veřejně dostupných
-							otevřených dat registru silničních vozidel a evidence technických
-							prohlídek k uvedenému datu, <strong>není úředním dokumentem</strong> a
-							neobsahuje záznamy o nehodách ani zástavy/leasing. Stav tachometru
-							vychází ze záznamů technických a emisních prohlídek; není-li pro dané
-							vozidlo k dispozici, certifikát jej neobsahuje. Provozovatel neručí za
-							úplnost ani aktuálnost dat poskytovaných registrem a stanicemi
-							technické kontroly.
-						</li>
-						<li>
-							<strong>Reklamace.</strong> Nebude-li certifikát doručen nebo bude
-							vadný, kontaktujte provozovatele na e-mailu uvedeném níže; po ověření
-							zajistíme nápravu nebo vrácení platby.
-						</li>
-					</ul>
-				</section>
+				{certOn && (
+					<section className='mt-4'>
+						<h2 className='h4'>
+							6. Certifikát historie vozidla (placená služba)
+						</h2>
+						<p>
+							Provozovatel nabízí jednorázový digitální produkt „Certifikát
+							historie vozidla" – přehledný výpis údajů o vozidle zpracovaný z
+							veřejných otevřených dat registru silničních vozidel ČR a evidence
+							technických a emisních prohlídek (vlastníci a provozovatelé,
+							historie STK, historie stavu tachometru z prohlídek, dovoz a stav
+							vozidla) dodaný ve formátu PDF s QR kódem pro ověření pravosti.
+						</p>
+						<ul>
+							<li>
+								<strong>Cena.</strong> Cena je uvedena u produktu před
+								dokončením objednávky a je konečná. Provozovatel není plátcem
+								DPH, k ceně se proto DPH nepřipočítává.
+							</li>
+							<li>
+								<strong>Platba.</strong> Prodávajícím je provozovatel. Platbu
+								kartou nebo bankovním převodem zpracovává platební brána Comgate
+								(ComGate Payments, a.s.). Po připsání platby provozovatel
+								zpřístupní certifikát a zašle doklad o zaplacení na uvedený
+								e-mail.
+							</li>
+							<li>
+								<strong>Dodání.</strong> Certifikát je dodáván elektronicky –
+								ihned po připsání platby je zaslán na uvedený e-mail a
+								zpřístupněn ke stažení.
+							</li>
+							<li>
+								<strong>Odstoupení od smlouvy.</strong> Jde o digitální obsah
+								dodaný před uplynutím lhůty pro odstoupení. Kupující při
+								objednávce výslovně žádá o zahájení dodávání před uplynutím
+								čtrnáctidenní lhůty pro odstoupení a bere na vědomí, že tím v
+								souladu s § 1837 písm. l) zákona č. 89/2012 Sb., občanského
+								zákoníku, ztrácí právo na odstoupení od smlouvy.
+							</li>
+							<li>
+								<strong>Povaha údajů.</strong> Certifikát vychází z veřejně
+								dostupných otevřených dat registru silničních vozidel a evidence
+								technických prohlídek k uvedenému datu,{' '}
+								<strong>není úředním dokumentem</strong> a neobsahuje záznamy o
+								nehodách ani zástavy/leasing. Stav tachometru vychází ze záznamů
+								technických a emisních prohlídek; není-li pro dané vozidlo k
+								dispozici, certifikát jej neobsahuje. Provozovatel neručí za
+								úplnost ani aktuálnost dat poskytovaných registrem a stanicemi
+								technické kontroly.
+							</li>
+							<li>
+								<strong>Reklamace.</strong> Nebude-li certifikát doručen nebo
+								bude vadný, kontaktujte provozovatele na e-mailu uvedeném níže;
+								po ověření zajistíme nápravu nebo vrácení platby.
+							</li>
+						</ul>
+					</section>
+				)}
 
 				<section className='mt-4'>
-					<h2 className='h4'>7. Odpovědnost</h2>
+					<h2 className='h4'>{certOn ? '7' : '6'}. Odpovědnost</h2>
 					<p>
 						Informace poskytované službou jsou pouze orientační. Provozovatel
-						nenese odpovědnost za případné škody vzniklé v důsledku spoléhání
-						se na tyto informace.
+						nenese odpovědnost za případné škody vzniklé v důsledku spoléhání se
+						na tyto informace.
 					</p>
 					<p>
 						Emailová upozornění jsou poskytována jako doplňková funkce bez
@@ -162,8 +178,8 @@ const TermsPage: React.FC = () => {
 					</p>
 					<p>
 						Provozovatel nenese odpovědnost za škody způsobené nedoručením nebo
-						opožděným doručením emailových upozornění. Uživatel je povinen sledovat
-						své zákonné a smluvní termíny samostatně.
+						opožděným doručením emailových upozornění. Uživatel je povinen
+						sledovat své zákonné a smluvní termíny samostatně.
 					</p>
 					<p>
 						Uživatel je povinen ověřit si důležité informace u příslušných úřadů
@@ -172,10 +188,10 @@ const TermsPage: React.FC = () => {
 				</section>
 
 				<section className='mt-4'>
-					<h2 className='h4'>8. Změny podmínek</h2>
+					<h2 className='h4'>{certOn ? '8' : '7'}. Změny podmínek</h2>
 					<p>
-						Provozovatel si vyhrazuje právo tyto podmínky kdykoliv změnit.
-						O změnách bude uživatel informován emailem nebo oznámením ve službě.
+						Provozovatel si vyhrazuje právo tyto podmínky kdykoliv změnit. O
+						změnách bude uživatel informován emailem nebo oznámením ve službě.
 					</p>
 					<p>
 						Pokračováním v používání služby po změně podmínek uživatel vyjadřuje
@@ -184,7 +200,7 @@ const TermsPage: React.FC = () => {
 				</section>
 
 				<section className='mt-4'>
-					<h2 className='h4'>9. Kontakt</h2>
+					<h2 className='h4'>{certOn ? '9' : '8'}. Kontakt</h2>
 					<p>
 						V případě dotazů nebo připomínek nás kontaktujte na emailu:{' '}
 						vininfo(zavináč)mail.vininfo.cz

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -20,8 +20,9 @@ const TermsPage: React.FC = () => {
 					<p>
 						Tyto obchodní podmínky (dále jen „podmínky") upravují práva a
 						povinnosti uživatelů služby VINInfo (dále jen „služba") provozované
-						fyzickou osobou Bc. Václav Gabriel, IČO 88350207 (dále jen
-						„provozovatel").
+						fyzickou osobou Bc. Václav Gabriel, se sídlem Krkoškova 1662/37,
+						613 00 Brno, IČO 88350207, zapsanou v živnostenském rejstříku (dále
+						jen „provozovatel"). Provozovatel není plátcem DPH.
 					</p>
 					<p>
 						Používáním služby uživatel souhlasí s těmito podmínkami a zavazuje


### PR DESCRIPTION
## Comgate payment provider (default), Lemon Squeezy kept as fallback

Adds **Comgate** (Czech PSP) as the certificate payment provider and makes it the default; **Lemon Squeezy** is preserved intact as a fallback (`PAYMENT_PROVIDER=lemonsqueezy`).

**Why Comgate:** it's a Czech company, so we are the seller (no VAT as a sub-2M neplátce), its fees are a *domestic* supply (no *identifikovaná osoba* from the gateway, unlike a foreign MoR), and it's cheaper per 99 Kč sale.

### Changes
- `api/_payments.ts` → `PAYMENT_PROVIDER` switch (`'comgate' | 'lemonsqueezy'`, default comgate):
  - Comgate v1.0: `/create` (refId = cert code, `prepareOnly`, `test=true` off production, redirect URLs) → redirect + `transId`; webhook parses the form notification, **authenticates via the echoed `secret`** (timing-safe) and **re-queries `/status`** as the source of truth.
  - `verifyAndParseWebhook` is now async; `webhookAckBody()` returns the provider ack (Comgate: `code=0&message=OK`).
  - All Lemon Squeezy logic preserved (renamed internal `lemonSqueezy*`).
- `api/certificate/[...slug].ts` → webhook `await`s the async verify, sends the provider-aware ack, operator-alert copy made provider-neutral.
- `.env.example` → `PAYMENT_PROVIDER`, `COMGATE_MERCHANT`, `COMGATE_SECRET`.

### To activate (after signing Comgate)
1. Set `COMGATE_MERCHANT` + `COMGATE_SECRET` (+ optionally `PAYMENT_PROVIDER=comgate`, now the default) in Vercel.
2. In the Comgate portal set the push/notification URL → `https://vininfo.cz/api/certificate/webhook`.
3. Off production it sends `test=true` for sandbox payments. The live create→redirect→/status path needs real merchant credentials to test.

> **Stacked PR:** based on `ci/odometer-cron-node22-slim` (the webhook route changes build on the direct-checkout-alert commit there). GitHub will retarget this to `main` once that PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
